### PR TITLE
Fix incorrect parameter to Mcu::loadSounds

### DIFF
--- a/librdpiano/src/mcu.cpp
+++ b/librdpiano/src/mcu.cpp
@@ -256,7 +256,7 @@ Mcu::Mcu(const u8 *temp_ic5, const u8 *temp_ic6, const u8 *temp_ic7, const u8 *t
     program_rom[srcpos] = UNSCRAMBLE_DATA_CPUB(temp_progrom[UNSCRAMBLE_ADDR_CPUB(srcpos)]);
   }
 
-  loadSounds(temp_ic5, temp_ic6, temp_ic7, temp_progrom, 0x00);
+  loadSounds(temp_ic5, temp_ic6, temp_ic7, temp_paramsrom, 0x00);
 
   m_ppc.d = 0;
   m_pc.d = 0;


### PR DESCRIPTION
Smaller temp_progrom was being sent insteam of larger temp_paramsrom, causing an out of bounds error when running rdpiano_standalone with the AddressSanitizer enabled.

==5808==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x00016d16ace0 at pc 0x000102cc50e8 bp 0x00016d108040 sp 0x00016d108038
READ of size 1 at 0x00016d16ace0 thread T0
    #0 0x000102cc50e4 in Mcu::loadSounds(unsigned char const*, unsigned char const*, unsigned char const*, unsigned char const*, unsigned long)+0x138 (rdpiano_standalone:arm64+0x1000510e4)
    #1 0x000102cc463c in Mcu::Mcu(unsigned char const*, unsigned char const*, unsigned char const*, unsigned char const*, unsigned char const*)+0x12a4 (rdpiano_standalone:arm64+0x10005063c)
    #2 0x000102cc55a0 in Mcu::Mcu(unsigned char const*, unsigned char const*, unsigned char const*, unsigned char const*, unsigned char const*)+0x40 (rdpiano_standalone:arm64+0x1000515a0)
    #3 0x000102c76ffc in main+0x59c (rdpiano_standalone:arm64+0x100002ffc)
    #4 0x000183326b94 in start+0x17b8 (dyld:arm64e+0xfffffffffff3ab94)

Address 0x00016d16ace0 is located in stack of thread T0 at offset 402208 in frame
    #0 0x000102c76a6c in main+0xc (rdpiano_standalone:arm64+0x100002a6c)

  This frame has 7 object(s):
    [32, 131104) 'temp_ic5'
    [131360, 262432) 'temp_ic6'
    [262688, 393760) 'temp_ic7'
    [394016, 402208) 'temp_progrom' <== Memory access at offset 402208 overflows this variable
    [402464, 533536) 'temp_paramsrom'
    [533792, 533793) 'ref.tmp'
    [533808, 533864) 'sdl_event'