### PR TITLE
Add Linux build to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,45 @@ jobs:
               ./rdpiano_juce/Builds/MacOSX/build/Release/rdpiano_juce.vst3.macOS.zip
               ./rdpiano_juce/Builds/MacOSX/build/Release/rdpiano_juce.component.macOS.zip
               ./rdpiano_juce/Builds/MacOSX/build/Release/rdpiano_juce.app.macOS.zip
+  build-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: "Install Dependencies"
+        run: sudo apt update && sudo apt install -y libasound2-dev libjack-jackd2-dev libxcursor-dev libxinerama-dev libxrandr-dev
+      - name: "Download Projucer"
+        run: |
+          cd rdpiano_juce
+          git clone -b 8.0.1 --depth 1 https://github.com/juce-framework/JUCE JUCE
+          bash -ex ./build/download-projucer.sh
+        shell: bash
+        env:
+          OS: linux
+      - name: "Build RdPiano"
+        run: sh -ex ./rdpiano_juce/build/build-linux.sh
+        shell: bash
+      - name: "Zip Artifacts"
+        run: |
+          cd ./rdpiano_juce/Builds/LinuxMakefile/build/
+          zip -r rdpiano_juce.vst3.Linux.zip rdpiano_juce.vst3
+          zip -r rdpiano_juce.lv2.Linux.zip rdpiano_juce.lv2
+          cd -
+        shell: bash
+      - name: "Upload Artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: RdPiano-linux
+          path: |
+            ./rdpiano_juce/Builds/LinuxMakefile/build/rdpiano_juce.vst3.Linux.zip
+            ./rdpiano_juce/Builds/LinuxMakefile/build/rdpiano_juce.lv2.Linux.zip
+            ./rdpiano_juce/Builds/LinuxMakefile/build/rdpiano_juce
+
   release:
     name: "Release"
-    needs: [build-win, build-osx]
+    needs: [build-win, build-osx, build-linux]
     if: github.ref == 'refs/heads/main'
     runs-on: "ubuntu-latest"
     steps:


### PR DESCRIPTION
This PR adds a `build-linux` job to the GitHub Actions workflow. The build produces a VST3 and a LV2 plugin, in addition to a Linux binary, which should all be uploaded as artifacts on the next release.

Resolves #30